### PR TITLE
Add covariance stability test and improve GaussianMixture cov() method

### DIFF
--- a/pyest/gm/gm.py
+++ b/pyest/gm/gm.py
@@ -871,18 +871,33 @@ class GaussianMixture(object):
         return np.sum(self.w[:, np.newaxis] * self.m, axis=0)
 
     def cov(self):
-        """ return covariance of the distribution
+        """Compute the covariance matrix of the distribution.
 
         Returns
         -------
         ndarray
-          (nx,nx) full covariance matrix of distribution
+            (nx, nx) full covariance matrix of the distribution
         """
-        wsum = np.sum(self.w)
+        # Compute the mean of the distribution
         mean = self.mean()
-        return np.sum([
-            w/wsum*(P + np.outer(m, m)) for w, m, P in self
-        ], axis=0) - np.outer(mean, mean)
+        
+        # Extract weights for each sample (assuming self.w exists)
+        w = self.w
+        
+        # Normalise weights to sum to 1
+        w = w / np.sum(w)
+        
+        # Extract individual covariances (self.P should be shape (n_samples, nx, nx))
+        covs = self.P
+        
+        # Compute the difference between each sample and the mean
+        diffs = self.m - mean  # shape (n_samples, nx)
+        
+        # Compute the outer product of diffs for each sample
+        outer_diffs = diffs[:, :, None] * diffs[:, None, :]  # shape (n_samples, nx, nx)
+        
+        # Weighted sum of covariances and outer products
+        return np.sum(w[:, None, None] * (covs + outer_diffs), axis=0)
 
     def cdf(self, x, allow_singular=False):
         """ evaluate GM CDF at points x"""
@@ -1024,3 +1039,4 @@ class GaussSplitOptions(object):
         self.state_idxs = np.array(state_idxs)
         self.spectral_direction_only = spectral_direction_only
         self.variance_preserving = variance_preserving
+


### PR DESCRIPTION
Refactored GaussianMixture.cov() to handle means and covariances with large differences in magnitude in a vectorized form. Added test_cov() to ensure recursive Gaussian splitting does not alter covariance beyond 0.01%, using Cholesky factors and the maximum covariance ratio for verification. This improves numerical stability checks and test coverage for GMM splitting.